### PR TITLE
convert geojson

### DIFF
--- a/marble_api/utils/geojson.py
+++ b/marble_api/utils/geojson.py
@@ -1,7 +1,17 @@
 from collections.abc import Iterable
 from itertools import zip_longest
 
-from geojson_pydantic import LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon
+from geojson_pydantic import (
+    Feature,
+    FeatureCollection,
+    GeometryCollection,
+    LineString,
+    MultiLineString,
+    MultiPoint,
+    MultiPolygon,
+    Point,
+    Polygon,
+)
 from geojson_pydantic.types import (
     BBox,
     LineStringCoords,
@@ -12,7 +22,9 @@ from geojson_pydantic.types import (
     Position,
 )
 
+# Note: STAC Geometry differs from the GeoJSON Geometry definition (GeometryCollection not included)
 type Geometry = LineString | MultiLineString | MultiPoint | MultiPolygon | Point | Polygon
+type GeoJSON = Geometry | FeatureCollection | Feature | GeometryCollection
 type Coordinates = (
     LineStringCoords | MultiLineStringCoords | MultiPointCoords | MultiPolygonCoords | PolygonCoords | Position
 )
@@ -33,3 +45,66 @@ def bbox_from_coordinates(coordinates: Coordinates) -> BBox:
         real_values = [v or 0 for v in values]  # coordinates without elevation are considered to be at elevation 0
         min_max.append((min(real_values), max(real_values)))
     return [v for val in min_max for v in val]
+
+
+def _validate_geometries(geometries: list[Geometry], geojson_type: str) -> None:
+    geometry_types = frozenset({geo.type for geo in geometries})
+    if len(geometry_types) != 1 and geometry_types not in {
+        frozenset(),
+        frozenset(("Point", "MultiPoint")),
+        frozenset(("LineString", "MultiLineString")),
+        frozenset(("Polygon", "MultiPolygon")),
+    }:
+        raise ValueError(f"GeoJSON of type '{geojson_type}' is not convertable to a STAC compliant geometry.")
+
+
+def _extract_geometries(geojson: GeoJSON | None) -> list[Geometry]:
+    """Return all geometries present in the geojson as a flat list."""
+    if geojson.type == "FeatureCollection":
+        return [geo for feature in geojson.features for geo in _extract_geometries(feature.geometry) if geo]
+    if geojson.type == "GeometryCollection":
+        return geojson.geometries
+    if geojson.type == "Feature":
+        return _extract_geometries(geojson.geometry)
+    if geojson is None:
+        return []
+    return [geojson]
+
+
+def validate_collapsible(geojson: GeoJSON) -> None:
+    """Raise a ValueError if the geojson cannot be collapsed to a STAC compatible geometry."""
+    _validate_geometries(_extract_geometries(geojson), geojson.type)
+
+
+def collapse_geometries(geojson: GeoJSON, check: bool = True) -> Geometry | None:
+    """
+    Return a single geometry that represents the same geo-spatial data as the geojson.
+
+    This will collapse Features, FeatureCollections, and GeometryCollections into other
+    geometry types that represent the same points, lines, or polygons. The converted geometries
+    are compatible with STAC.
+
+    If check is False, this will not validate that the geojson can be collapsed before attempting
+    to collapse it. This may result in undefined behaviour. It is strongly recommended that you
+    call validate_collapsible(geojson) prior to calling this function with check=False.
+    """
+    geometries = _extract_geometries(geojson)
+    if check:
+        _validate_geometries(geometries, geojson.type)
+    if not geometries:
+        return None
+    if len(geometries) == 1:
+        return geometries[0]
+    coordinates = []
+    for geo in geometries:
+        if geo.type in ("Point", "LineString", "Polygon"):
+            coordinates.append(geo.coordinates)
+        else:
+            coordinates.extend(geo.coordinates)
+        if geo.type in ("Point", "MultiPoint"):
+            geo_type = MultiPoint
+        elif geo.type in ("LineString", "MultiLineString"):
+            geo_type = MultiLineString
+        else:
+            geo_type = MultiPolygon
+    return geo_type(coordinates=coordinates, type=geo_type.__name__)

--- a/test/unit/utils/test_utils_geojson.py
+++ b/test/unit/utils/test_utils_geojson.py
@@ -1,4 +1,22 @@
-from marble_api.utils.geojson import bbox_from_coordinates
+import pytest
+from faker import Faker
+from geojson_pydantic import (
+    Feature,
+    FeatureCollection,
+    GeometryCollection,
+    MultiLineString,
+    MultiPoint,
+    MultiPolygon,
+)
+
+from marble_api.utils.geojson import bbox_from_coordinates, collapse_geometries, validate_collapsible
+
+
+@pytest.fixture(scope="session")
+def fake(faker_providers) -> Faker:
+    fake_ = Faker()
+    fake_.add_provider(faker_providers["GeoJsonProvider"])
+    return fake_
 
 
 class TestBboxFromCoordinates:
@@ -22,3 +40,117 @@ class TestBboxFromCoordinates:
 
     def test_different_nested(self):
         assert bbox_from_coordinates([[1, 2], [[[-1, -3, 33]]]]) == [-1, 1, -3, 2, 0, 33]
+
+
+@pytest.mark.parametrize("dimensions", [2, 3])
+class TestValidateCollapsible:
+    def test_collapsible(self, fake, dimensions):
+        errors = []
+        for geo in fake.collapsible_geojsons(dimensions):
+            try:
+                validate_collapsible(geo)
+            except ValueError:
+                errors.append(geo)
+        assert not errors, "These geojsons should be collapsible but weren't properly collapsed"
+
+    def test_uncollapsible(self, fake, dimensions):
+        errors = []
+        for geo in fake.uncollapsible_geojsons(dimensions):
+            try:
+                validate_collapsible(geo)
+            except ValueError:
+                pass
+            else:
+                errors.append(geo)
+        assert not errors, "These geojsons should be uncollapsible but were properly collapsed"
+
+
+@pytest.mark.parametrize("dimensions", [2, 3])
+class TestCollapseGeometries:
+    def test_no_change_to_stac_geometries(self, fake, dimensions):
+        geometries = fake.stac_geometries(dimensions)
+        assert [collapse_geometries(geo) for geo in geometries] == geometries
+
+    def test_cannot_collapse_uncollapsible(self, fake, dimensions):
+        for geo in fake.uncollapsible_geojsons(dimensions):
+            with pytest.raises(ValueError):
+                collapse_geometries(geo)
+
+    def test_collapsible_geojson_changed(self, fake, dimensions):
+        not_changed = []
+        stac_geometry_types = [geo.type for geo in fake.stac_geometries()]
+        for geo in fake.collapsible_geojsons(dimensions):
+            if geo.type not in stac_geometry_types:
+                if collapse_geometries(geo) == geo:
+                    not_changed.append(geo)
+        assert not not_changed, "These geojsons should have been collapsed/changed but they weren't"
+
+    def test_feature_changed(self, fake, dimensions):
+        not_changed = []
+        for feat in fake.collapsible_features(dimensions):
+            if feat.geometry.type != "GeometryCollection":
+                if collapse_geometries(feat) != feat.geometry:
+                    not_changed.append(feat)
+        assert not not_changed, "These features should have been collapsed to their geometry but they weren't"
+
+    @pytest.mark.parametrize(
+        "geometries",
+        [
+            {"geos": ["point", "multipoint"], "result": MultiPoint},
+            {"geos": ["linestring", "multilinestring"], "result": MultiLineString},
+            {"geos": ["polygon", "multipolygon"], "result": MultiPolygon},
+        ],
+        ids=lambda val: val["result"].__name__,
+    )
+    @pytest.mark.parametrize(
+        "geo_factory",
+        [
+            (
+                "GeometryCollection(Geometry)",
+                lambda geos: GeometryCollection(type="GeometryCollection", geometries=geos),
+            ),
+            (
+                "Feature(GeometryCollection(Geometry))",
+                lambda geos: Feature(
+                    type="Feature",
+                    properties={},
+                    geometry=GeometryCollection(type="GeometryCollection", geometries=geos),
+                ),
+            ),
+            (
+                "FeatureCollection(Feature(GeometryCollection(Geometry)))",
+                lambda geos: FeatureCollection(
+                    type="FeatureCollection",
+                    features=[
+                        Feature(
+                            type="Feature",
+                            properties={},
+                            geometry=GeometryCollection(type="GeometryCollection", geometries=geos),
+                        )
+                    ],
+                ),
+            ),
+            (
+                "FeatureCollection(Feature(Geometry))",
+                lambda geos: FeatureCollection(
+                    type="FeatureCollection",
+                    features=[
+                        Feature(
+                            type="Feature",
+                            properties={},
+                            geometry=geo,
+                        )
+                        for geo in geos
+                    ],
+                ),
+            ),
+        ],
+        ids=lambda val: val[0],
+    )
+    def test_complex_collapsible(self, fake, dimensions, geometries, geo_factory):
+        geos = [getattr(fake, f"geo_{geo}")(dimensions) for geo in geometries["geos"]]
+        result = geometries["result"]
+        factory_name, factory = geo_factory
+        assert collapse_geometries(factory(geos)) == result(
+            type=result.__name__, coordinates=[geos[0].coordinates, *geos[1].coordinates]
+        ), f"Unable to collapse {factory_name} into a {result.__name__}"


### PR DESCRIPTION
If a user uploads a GeoJSON that is not compatible with the STAC spec, we can try to convert it into a format that is compatible.

STAC supports all GeoJSON geometries except for geometry-collections. However, a user could upload a feature, geometry-collection, or feature collection. Previously, these were considered invalid geometries but in some cases they can be converted to a STAC-compliant geometry.

For example, a feature-collection containing a point and a multipoint or multiple points can be converted to a single multipoint containing the same point data; a geometry-collection containing 3 polygons can be converted to a multi-polygon.

This is especially useful if a user uploads a GeoJSON generated by a website like geojson.io which always generates feature-collections.

When a user uploads a GeoJSON, it is validated to ensure that it can be converted to a STAC-compliant format. When the STAC representation of a data request is created, the uploaded geometry is then converted and added to the generated STAC item.