### PR TITLE
convert timezones to utc

### DIFF
--- a/marble_api/versions/v1/data_request/models.py
+++ b/marble_api/versions/v1/data_request/models.py
@@ -1,4 +1,5 @@
 from collections.abc import Sized
+from datetime import timezone
 from typing import Required, TypedDict
 
 from bson import ObjectId
@@ -124,11 +125,11 @@ class DataRequestPublic(DataRequest):
 
         # STAC spec recommends including datetime even if using start_datetime and end_datetime
         # See: https://github.com/radiantearth/stac-spec/blob/master/best-practices.md#datetime-selection
-        item["properties"]["datetime"] = self.temporal[0].isoformat()
+        item["properties"]["datetime"] = self.temporal[0].astimezone(timezone.utc).isoformat()
 
         if len(set(self.temporal)) > 1:
             item["properties"]["start_datetime"], item["properties"]["end_datetime"] = [
-                t.isoformat() for t in self.temporal
+                t.astimezone(timezone.utc).isoformat() for t in self.temporal
             ]
 
         if self.geometry:

--- a/test/unit/versions/v1/data_request/test_models.py
+++ b/test/unit/versions/v1/data_request/test_models.py
@@ -132,6 +132,28 @@ class TestDataRequestPublic(TestDataRequest):
             assert request.stac_item["properties"]["start_datetime"] == temporal[0].isoformat()
             assert request.stac_item["properties"]["end_datetime"] == temporal[1].isoformat()
 
+        def test_temporal_to_utc(self, fake_class):
+            now = datetime.datetime.now(tz=datetime.timezone.utc)
+            offset = datetime.timezone(datetime.timedelta(hours=3))
+            temporal = [now, now + datetime.timedelta(hours=1)]
+            temporal_offset = [t.astimezone(offset) for t in temporal]
+            request = fake_class(temporal=temporal_offset)
+            assert (
+                request.stac_item["properties"]["datetime"]
+                == temporal[0].isoformat()
+                == temporal_offset[0].astimezone(datetime.timezone.utc).isoformat()
+            )
+            assert (
+                request.stac_item["properties"]["start_datetime"]
+                == temporal[0].isoformat()
+                == temporal_offset[0].astimezone(datetime.timezone.utc).isoformat()
+            )
+            assert (
+                request.stac_item["properties"]["end_datetime"]
+                == temporal[1].isoformat()
+                == temporal_offset[1].astimezone(datetime.timezone.utc).isoformat()
+            )
+
         def test_extra_properties(self, fake_class):
             request = fake_class()
             item = request.stac_item


### PR DESCRIPTION
Temporal data can be uploaded with any timezone offset but is converted to UTC when creating a STAC Item.