### PR TITLE
handle multiple timezones

### DIFF
--- a/marble_api/versions/v1/data_request/routes.py
+++ b/marble_api/versions/v1/data_request/routes.py
@@ -64,7 +64,6 @@ async def patch_data_request(
         data_request.user = user
     selector = {"_id": _data_request_id(request_id)}
     if updated_fields:
-        updated_fields.update(data_request.model_dump(include="stac_item"))
         result = await client.db["data-request"].find_one_and_update(
             selector, {"$set": updated_fields}, return_document=ReturnDocument.AFTER
         )

--- a/test/faker_providers.py
+++ b/test/faker_providers.py
@@ -1,5 +1,3 @@
-import datetime
-
 import bson
 import pytest
 from faker import Faker
@@ -192,22 +190,22 @@ class DataRequestProvider(GeoJsonProvider):
             author_["email"] = self.generator.email()
         return author_
 
-    def utc_date_time_seconds_precision(self):
-        return self.generator.date_time(tzinfo=datetime.timezone.utc).replace(microsecond=0)
+    def tz_aware_date_time_seconds_precision(self):
+        return self.generator.date_time(tzinfo=self.generator.pytimezone()).replace(microsecond=0)
 
     def temporal(self):
         opt = self.generator.random.random()
         if opt < 1 / 3:
             return sorted(
                 [
-                    self.utc_date_time_seconds_precision(),
-                    self.utc_date_time_seconds_precision(),
+                    self.tz_aware_date_time_seconds_precision(),
+                    self.tz_aware_date_time_seconds_precision(),
                 ]
             )
         elif opt < 2 / 3:
-            return [self.utc_date_time_seconds_precision()] * 2
+            return [self.tz_aware_date_time_seconds_precision()] * 2
         else:
-            return [self.utc_date_time_seconds_precision()]
+            return [self.tz_aware_date_time_seconds_precision()]
 
     def link(self):
         return {"href": self.generator.uri(), "rel": self.generator.word(), "type": self.generator.mime_type()}

--- a/test/integration/versions/v1/data_request/test_routes.py
+++ b/test/integration/versions/v1/data_request/test_routes.py
@@ -7,7 +7,7 @@ import pytest
 from stac_pydantic import Item
 
 from marble_api.database import client
-from marble_api.versions.v1.data_request.models import DataRequest, DataRequestPublic
+from marble_api.versions.v1.data_request.models import DataRequestPublic
 from marble_api.versions.v1.data_request.routes import get_data_requests
 
 pytestmark = pytest.mark.anyio
@@ -226,11 +226,10 @@ class _TestPost:
         data = fake.data_request().model_dump_json(exclude=["user"])
         response = await async_client.post(collection_route, json=json.loads(data))
         assert response.status_code == 200
-        assert (id_ := response.json().get("id"))
+        response_data = response.json()
+        assert (id_ := response_data.pop("id", None))
         bson.ObjectId(id_)  # check that the id is a valid object id
-        assert {"user": data_requests[0]["user"], **json.loads(data)} == json.loads(
-            DataRequest(**response.json()).model_dump_json()
-        )
+        assert {"user": data_requests[0]["user"], **json.loads(data)} == response_data
 
     async def test_invalid_authors(self, fake, async_client, collection_route):
         data = json.loads(fake.data_request().model_dump_json())

--- a/test/unit/versions/v1/data_request/test_models.py
+++ b/test/unit/versions/v1/data_request/test_models.py
@@ -137,7 +137,7 @@ class TestDataRequestPublic(TestDataRequest):
             offset = datetime.timezone(datetime.timedelta(hours=3))
             temporal = [now, now + datetime.timedelta(hours=1)]
             temporal_offset = [t.astimezone(offset) for t in temporal]
-            request = fake_class(temporal=temporal_offset)
+            request = fake_class(temporal=[t.isoformat() for t in temporal_offset])
             assert (
                 request.stac_item["properties"]["datetime"]
                 == temporal[0].isoformat()


### PR DESCRIPTION
If temporal data is uploaded with non-UTC timezone offsets then store those timezones with offsets.
When exporting STAC items, convert the time to UTC.
This is necessary because mongodb stores datetime objects as UTC **only**.